### PR TITLE
cleaned gitignore : 2x .env*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ node_modules
 yarn-error.log
 .byebug_history
 .env*
-.env*


### PR DESCRIPTION
We had twice ".env*" inside the ".gitignore" file